### PR TITLE
Implemented handling for creating primary and secondary contacts based on incoming requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/bitespeed/backendTask/controller/UserController.java
+++ b/src/main/java/com/bitespeed/backendTask/controller/UserController.java
@@ -1,18 +1,39 @@
 package com.bitespeed.backendTask.controller;
 
 import com.bitespeed.backendTask.model.RequestContactInfoModel;
+import com.bitespeed.backendTask.service.impl.IdentificationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1")
 public class UserController {
+    Logger log = (Logger) LoggerFactory.getLogger(this.getClass());
 
-    @GetMapping("/identify")
-    public ResponseEntity<?> identifyUser(@RequestBody RequestContactInfoModel contactModel){
+    @Autowired
+    private IdentificationService identificationService;
+
+
+
+
+    @PostMapping("/identify")
+    public ResponseEntity<?> identifyUser(@RequestBody RequestContactInfoModel contactModel) {
+        String email = contactModel.getEmail();
+        String phoneNumber = contactModel.getPhoneNumber();
+        try {
+            if(email !=null && phoneNumber != null){
+                log.info("Inside where both email and phone number exists");
+                return ResponseEntity.ok(identificationService.fetchContactInfo(email,phoneNumber));
+            }
+
+        } catch (Exception e) {
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred.");
+        }
         return null;
     }
 

--- a/src/main/java/com/bitespeed/backendTask/entity/Auditable.java
+++ b/src/main/java/com/bitespeed/backendTask/entity/Auditable.java
@@ -1,0 +1,14 @@
+package com.bitespeed.backendTask.entity;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public interface Auditable {
+
+    void setCreatedAt(Date createdAt);
+    void setUpdatedAt(Date updatedAt);
+
+    void setDeletedAt(Date deletedAt);
+}

--- a/src/main/java/com/bitespeed/backendTask/entity/Contact.java
+++ b/src/main/java/com/bitespeed/backendTask/entity/Contact.java
@@ -1,0 +1,133 @@
+package com.bitespeed.backendTask.entity;
+
+import com.bitespeed.backendTask.utils.AuditListeners;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Entity
+@Table(name = "Contact")
+@EntityListeners(AuditListeners.class)
+public class Contact implements Auditable{
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        @Column(name = "phoneNumber")
+        private String phoneNumber;
+
+        @Column(name = "email")
+        private String email;
+
+        @Column(name = "linkedId")
+        private Long linkedId;
+
+        @Column(name = "linkPrecedence")
+        private String linkPrecedence;
+
+        @Column(name = "createdAt")
+        @Temporal(TemporalType.TIMESTAMP)
+        private Date createdAt;
+
+        @Column(name = "updatedAt")
+        @Temporal(TemporalType.TIMESTAMP)
+        private Date updatedAt;
+
+        @Column(name = "deletedAt")
+        @Temporal(TemporalType.TIMESTAMP)
+        private Date deletedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Long getLinkedId() {
+        return linkedId;
+    }
+
+    public void setLinkedId(Long linkedId) {
+        this.linkedId = linkedId;
+    }
+
+    public String getLinkPrecedence() {
+        return linkPrecedence;
+    }
+
+    public void setLinkPrecedence(String linkPrecedence) {
+        this.linkPrecedence = linkPrecedence;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Date getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(Date deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    public Contact(Long id, String phoneNumber, String email, Long linkedId, String linkPrecedence, Date createdAt, Date updatedAt, Date deletedAt) {
+        this.id = id;
+        this.phoneNumber = phoneNumber;
+        this.email = email;
+        this.linkedId = linkedId;
+        this.linkPrecedence = linkPrecedence;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
+    }
+
+    public Contact() {
+    }
+
+    @Override
+    public String toString() {
+        return "Contact{" +
+                "id=" + id +
+                ", phoneNumber='" + phoneNumber + '\'' +
+                ", email='" + email + '\'' +
+                ", linkedId=" + linkedId +
+                ", linkPrecedence='" + linkPrecedence + '\'' +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", deletedAt=" + deletedAt +
+                '}';
+    }
+}

--- a/src/main/java/com/bitespeed/backendTask/model/ResponseContactInfoModel.java
+++ b/src/main/java/com/bitespeed/backendTask/model/ResponseContactInfoModel.java
@@ -8,12 +8,12 @@ import java.util.*;
 @Component
 public class ResponseContactInfoModel implements Serializable {
 
-    private int primaryContactId;
+    private Long primaryContactId;
     private List<String> emails;
     private List<String> phoneNumbers;
-    private List<Integer> secondaryContactIds;
+    private List<Long> secondaryContactIds;
 
-    public ResponseContactInfoModel(int primaryContactId, List<String> emails, List<String> phoneNumbers, List<Integer> secondaryContactIds) {
+    public ResponseContactInfoModel(Long primaryContactId, List<String> emails, List<String> phoneNumbers, List<Long> secondaryContactIds) {
         this.primaryContactId = primaryContactId;
         this.emails = emails;
         this.phoneNumbers = phoneNumbers;
@@ -23,11 +23,11 @@ public class ResponseContactInfoModel implements Serializable {
     public ResponseContactInfoModel() {
     }
 
-    public int getPrimaryContactId() {
+    public Long getPrimaryContactId() {
         return primaryContactId;
     }
 
-    public void setPrimaryContactId(int primaryContactId) {
+    public void setPrimaryContactId(Long primaryContactId) {
         this.primaryContactId = primaryContactId;
     }
 
@@ -47,11 +47,11 @@ public class ResponseContactInfoModel implements Serializable {
         this.phoneNumbers = phoneNumbers;
     }
 
-    public List<Integer> getSecondaryContactIds() {
+    public List<Long> getSecondaryContactIds() {
         return secondaryContactIds;
     }
 
-    public void setSecondaryContactIds(List<Integer> secondaryContactIds) {
+    public void setSecondaryContactIds(List<Long> secondaryContactIds) {
         this.secondaryContactIds = secondaryContactIds;
     }
 

--- a/src/main/java/com/bitespeed/backendTask/repository/ContactRepository.java
+++ b/src/main/java/com/bitespeed/backendTask/repository/ContactRepository.java
@@ -1,0 +1,28 @@
+package com.bitespeed.backendTask.repository;
+
+import com.bitespeed.backendTask.entity.Contact;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ContactRepository extends JpaRepository<Contact,Long> {
+
+
+    Contact findByEmailAndPhoneNumber(String email, String phoneNumber);
+    @Query("SELECT c FROM Contact c WHERE c.email = :email OR c.phoneNumber = :phoneNumber")
+    List<Contact> findByEmailOrPhoneNumber(@Param("email") String email, @Param("phoneNumber") String phoneNumber);
+
+    List<Contact> findByEmail(String email);
+
+    List<Contact> findByPhoneNumber(String phoneNumber);
+
+
+    Contact findByEmailAndLinkPrecedence(String email,String precedence);
+    Contact findByPhoneNumberAndLinkPrecedence(String phoneNumber,String precedence);
+
+
+}

--- a/src/main/java/com/bitespeed/backendTask/service/impl/IdentificationOperationServices.java
+++ b/src/main/java/com/bitespeed/backendTask/service/impl/IdentificationOperationServices.java
@@ -1,0 +1,39 @@
+package com.bitespeed.backendTask.service.impl;
+
+import com.bitespeed.backendTask.entity.Contact;
+import com.bitespeed.backendTask.model.ResponseContactInfoModel;
+import com.bitespeed.backendTask.repository.ContactRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import java.util.*;
+
+@Service
+public class IdentificationOperationServices {
+    Logger log = (Logger) LoggerFactory.getLogger(this.getClass());
+    @Autowired
+    private ContactRepository contactRepository;
+
+    @Autowired
+    private ResponseServices responseServices;
+
+
+    public ResponseContactInfoModel createNewUser(String email , String phoneNumber){
+        log.info(" inside createNewUserMethods : {} : {}",email,phoneNumber);
+        try{
+            Contact newContact = new Contact();
+            newContact.setEmail(email);
+            newContact.setPhoneNumber(phoneNumber);
+            newContact.setLinkPrecedence("primary");
+
+            contactRepository.save(newContact);
+            log.info("added as new User");
+            return responseServices.getContactInfo(email, phoneNumber);
+
+        }catch(Exception e){
+            return null;
+        }
+
+    }
+}

--- a/src/main/java/com/bitespeed/backendTask/service/impl/IdentificationService.java
+++ b/src/main/java/com/bitespeed/backendTask/service/impl/IdentificationService.java
@@ -1,0 +1,138 @@
+package com.bitespeed.backendTask.service.impl;
+
+import com.bitespeed.backendTask.entity.Contact;
+import com.bitespeed.backendTask.model.ResponseContactInfoModel;
+import com.bitespeed.backendTask.repository.ContactRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class IdentificationService {
+
+    private final Logger log = LoggerFactory.getLogger(IdentificationService.class);
+
+    @Autowired
+    private IdentificationOperationServices identificationOperationServices;
+
+    @Autowired
+    private ContactRepository contactRepository;
+
+    @Autowired
+    private ResponseServices responseServices;
+
+    public ResponseContactInfoModel fetchContactInfo(String email, String phoneNumber) {
+
+        try {
+
+            List<Contact> contacts = contactRepository.findByEmailOrPhoneNumber(email, phoneNumber);
+
+            if (contacts.isEmpty()) {
+
+                return responseServices.getContactInfo(email,phoneNumber);
+            } else {
+                Contact contact = contactRepository.findByEmailAndPhoneNumber(email, phoneNumber);
+
+                if (contact == null) {
+                    log.info("Contact found for email: {} and phone number: {}", email, phoneNumber);
+                    List<Contact> fetchedViaEmail = contactRepository.findByEmail(email);
+                    log.info("Fetched contacts via email: {}", fetchedViaEmail);
+                    List<Contact> fetchedViaPhoneNumber = contactRepository.findByPhoneNumber(phoneNumber);
+                    log.info("Fetched contacts via phone number: {}", fetchedViaPhoneNumber);
+                    if (fetchedViaEmail.isEmpty()) {
+                        userExistViaPhoneNumber(email, fetchedViaPhoneNumber);
+                        return responseServices.getContactInfo(email,phoneNumber);
+                    }else{
+                        userExistViaEmail(phoneNumber,fetchedViaEmail);
+                        return responseServices.getContactInfo(email,phoneNumber);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("An error occurred while fetching contact information: {}", e.getMessage(), e);
+        }
+        return responseServices.getContactInfo(email,phoneNumber);
+    }
+
+    public void userExistViaPhoneNumber(String email, List<Contact> fetchedViaPhoneNumber) {
+        try {
+            Contact primaryContact = null;
+            Contact secondaryContact = new Contact();
+
+            for (Contact c : fetchedViaPhoneNumber) {
+                if ("primary".equals(c.getLinkPrecedence())) {
+                    primaryContact = c;
+                    break;
+                }
+            }
+
+            if (primaryContact == null) {
+                Long size = (long) fetchedViaPhoneNumber.size();
+                primaryContact = fetchedViaPhoneNumber.get((int) (size - 1));
+                secondaryContact.setEmail(email);
+                secondaryContact.setPhoneNumber(primaryContact.getPhoneNumber());
+                secondaryContact.setLinkPrecedence("secondary");
+                secondaryContact.setLinkedId(primaryContact.getLinkedId());
+                contactRepository.save(secondaryContact);
+            }else{
+                secondaryContact.setEmail(email);
+                secondaryContact.setPhoneNumber(primaryContact.getPhoneNumber());
+                secondaryContact.setLinkPrecedence("secondary");
+                secondaryContact.setLinkedId(primaryContact.getId());
+                contactRepository.save(secondaryContact);
+            }
+
+
+        } catch (Exception e) {
+            log.error("An error occurred while processing user existence via phone number: {}", e.getMessage(), e);
+        }
+    }
+
+    public void userExistViaEmail(String phoneNumber, List<Contact> fetchedViaEmail){
+        try {
+            Contact primaryContact = null;
+            Contact secondaryContact = new Contact();
+
+            for (Contact c : fetchedViaEmail) {
+                if ("primary".equals(c.getLinkPrecedence())) {
+                    primaryContact = c;
+                    break;
+                }
+            }
+
+            if (primaryContact == null) {
+                Long size = (long) fetchedViaEmail.size();
+                primaryContact = fetchedViaEmail.get((int) (size - 1));
+                secondaryContact.setEmail(primaryContact.getEmail());
+                secondaryContact.setPhoneNumber(phoneNumber);
+                secondaryContact.setLinkPrecedence("secondary");
+                secondaryContact.setLinkedId(primaryContact.getLinkedId());
+                contactRepository.save(secondaryContact);
+            }else{
+                secondaryContact.setEmail(primaryContact.getEmail());
+                secondaryContact.setPhoneNumber(phoneNumber);
+                secondaryContact.setLinkPrecedence("secondary");
+                secondaryContact.setLinkedId(primaryContact.getId());
+                contactRepository.save(secondaryContact);
+            }
+
+
+        } catch (Exception e) {
+            log.error("An error occurred while processing user existence via phone number: {}", e.getMessage(), e);
+        }
+    }
+
+    public Object fetchContactInfoViaEmail(String email) {
+        //TODO: operations for if user provides only email
+        return null;
+    }
+
+    public Object fetchContactInfoViaPhoneNumber(String phoneNumber) {
+        //TODO: operations for if users provides only phone
+        return null;
+    }
+}

--- a/src/main/java/com/bitespeed/backendTask/service/impl/ResponseServices.java
+++ b/src/main/java/com/bitespeed/backendTask/service/impl/ResponseServices.java
@@ -1,0 +1,53 @@
+package com.bitespeed.backendTask.service.impl;
+
+import com.bitespeed.backendTask.entity.Contact;
+import com.bitespeed.backendTask.model.ResponseContactInfoModel;
+import com.bitespeed.backendTask.repository.ContactRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ResponseServices {
+    @Autowired
+    private ContactRepository contactRepository;
+
+    public ResponseContactInfoModel getContactInfo(String email, String phoneNumber) {
+        try {
+            List<Contact> contacts = contactRepository.findByEmailOrPhoneNumber(email, phoneNumber);
+            ResponseContactInfoModel response = new ResponseContactInfoModel();
+            Contact primaryContact = null;
+            List<Long> secondaryContactsID = new ArrayList<>();
+            List<String> phoneNumbers = new ArrayList<>();
+            List<String> emails = new ArrayList<>();
+
+            for (Contact c : contacts) {
+                if ("primary".equals(c.getLinkPrecedence())) {
+                    primaryContact = c;
+                } else {
+                    secondaryContactsID.add(c.getId());
+                }
+                phoneNumbers.add(c.getPhoneNumber());
+                emails.add(c.getEmail());
+            }
+
+            if (primaryContact != null) {
+                phoneNumbers.add(0, primaryContact.getPhoneNumber());
+                emails.add(0, primaryContact.getEmail());
+                response.setPrimaryContactId(primaryContact.getId());
+            }
+
+            response.setEmails(emails);
+            response.setPhoneNumbers(phoneNumbers);
+            response.setSecondaryContactIds(secondaryContactsID);
+
+            return response;
+
+        } catch (Exception e) {
+            e.printStackTrace(); // Log the exception for debugging purposes
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/bitespeed/backendTask/utils/AuditListeners.java
+++ b/src/main/java/com/bitespeed/backendTask/utils/AuditListeners.java
@@ -1,0 +1,42 @@
+package com.bitespeed.backendTask.utils;
+
+import com.bitespeed.backendTask.entity.Contact;
+import com.sun.tools.jconsole.JConsoleContext;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreRemove;
+import jakarta.persistence.PreUpdate;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+
+public class AuditListeners {
+
+
+    @PrePersist
+    public void setCreateFields(Object target){
+        if(target instanceof Contact){
+            Contact contact = (Contact) target;
+
+            contact.setCreatedAt(new Date());
+        }
+    }
+
+    @PreUpdate
+    public void setUpdateFields(Object target){
+        if(target instanceof Contact){
+            Contact contact = (Contact) target;
+            contact.setUpdatedAt(new Date());
+        }
+    }
+
+
+    @PreRemove
+    public void setDeleteFields(Object target){
+        if(target instanceof Contact){
+            Contact contact = (Contact) target;
+            contact.setDeletedAt(new Date());
+        }
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,12 @@
+server.port=8081
+spring.datasource.url=jdbc:mysql://localhost:3306/bitespeed
+spring.datasource.username=root
+spring.datasource.password=root
+
+spring.jpa.hibernate.ddl-auto=update
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.show-sql=false
+spring.jpa.hibernate.naming.physical-strategy = org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=backendTask
+spring.profiles.active = dev


### PR DESCRIPTION
This commit addresses two scenarios within the service's functionality related to managing contacts:

1. **Handling Non-Existing Contacts:** When there are no existing contacts associated with an incoming request, the service now creates a new Contact row with linkPrecedence="primary". This treats the incoming request as that of a new customer. Additionally, the service returns the created contact with an empty array for secondaryContactIds.

2. **Creation of Secondary Contacts:** If an incoming request shares either a phoneNumber or an email with an existing contact but contains new information, the service now creates a "secondary" Contact row to accommodate the updated details