### PR TITLE
Implement secondary contact linking logic

### DIFF
--- a/src/main/java/com/bitespeed/backendTask/service/impl/ResponseService.java
+++ b/src/main/java/com/bitespeed/backendTask/service/impl/ResponseService.java
@@ -22,10 +22,10 @@ public class ResponseService {
 
     public ResponseContactInfoModel getContactInfoViaEmailAndPhoneNumber(String email, String phoneNumber) {
         try {
-            // Log info level message for the start of the method execution
+
             log.info("Fetching contact information for email: {} and phone number: {}", email, phoneNumber);
 
-            // Initialize the response model and lists for email, phone numbers, and secondary IDs
+
             ResponseContactInfoModel response = new ResponseContactInfoModel();
             List<String> emails = new ArrayList<>();
             List<String> phoneNumbers = new ArrayList<>();


### PR DESCRIPTION
Added logic to identify primary contacts based on email and phone number, and link secondary contacts accordingly. If both primary contacts exist, the older contact is selected as the primary contact, and the other contact is linked as a secondary contact. This logic ensures proper linking of contacts in the database.